### PR TITLE
Make nginx for cpan.metacpan.org set a Surrogate-Control for  /authors/.*\.(gz|gzip|readme|meta|bz2)$

### DIFF
--- a/modules/metacpan/files/www/cpan.conf
+++ b/modules/metacpan/files/www/cpan.conf
@@ -1,5 +1,4 @@
-
 # Things in /authors/ that arn't likely to change
 location ~ /authors/.*\.(gz|gzip|readme|meta|bz2)$ {
-	add_header Surrogate-Control max-age=3600
+    add_header Surrogate-Control max-age=3600;
 }

--- a/modules/metacpan/manifests/web/cpan.pp
+++ b/modules/metacpan/manifests/web/cpan.pp
@@ -10,7 +10,7 @@ class metacpan::web::cpan {
 	file { "/etc/nginx/conf.d/cpan.metacpan.org.d/cdn-fastly.conf":
 		ensure => file,
 		source => ["puppet:///modules/metacpan/www/cpan.conf"],
-		require => File["/etc/nginx/conf.d/cpan.metacpan.d"],
+		require => File["/etc/nginx/conf.d/cpan.metacpan.org.d"],
 	}
 
 }


### PR DESCRIPTION
Can someone check this - the content/type seemed to switch to application/octet-stream for a .meta file - is this normal?
