### PR TITLE
Allow admins to sudo as any user, not just root

### DIFF
--- a/modules/metacpan/manifests/user.pp
+++ b/modules/metacpan/manifests/user.pp
@@ -95,7 +95,7 @@ define metacpan::user(
             owner => "root",
             group => "root",
             mode => "440",
-            content => "$user   ALL = ALL";
+            content => "$user   ALL = (ALL) ALL";
         }
     }
 }


### PR DESCRIPTION
Adds a RunAs spec to the per-user sudoer config.

This makes `sudo -iu metacpan` possible instead of necessitating going
through root first with `sudo su - metacpan`.

I do wonder why each user gets a sudoers file instead of simply adding
the user to the sudo group.
