### PR TITLE
update ssl config to remove SSLv2

### DIFF
--- a/modules/nginx/templates/vhost.conf.erb
+++ b/modules/nginx/templates/vhost.conf.erb
@@ -57,8 +57,8 @@ server {
   ssl_certificate  <%= @root %>/ssl/server.crt;
   ssl_certificate_key <%= @root %>/ssl/server.key;
   ssl_session_timeout  5m;
-  ssl_protocols  SSLv2 SSLv3 TLSv1;
-  ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP;
+  ssl_protocols  SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+EXP;
   ssl_prefer_server_ciphers on;
   <% end %>
   <% unless @bare %>


### PR DESCRIPTION
Remove SSLv2 from supported protocols.  Addresses part of CPAN-API/metacpan-web#1112.  This should probably be further improved when we get a new openssl version.
