### PR TITLE
Specify classes in hiera rather than node manifests

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,5 +1,8 @@
 ---
 
+classes:
+    - metacpan
+
 # Defaults
 perl::version: '5.18.2'
 

--- a/hieradata/env/6dg.yaml
+++ b/hieradata/env/6dg.yaml
@@ -1,1 +1,4 @@
 ---
+
+classes:
+    - metacpan::role::production

--- a/hieradata/env/bm.yaml
+++ b/hieradata/env/bm.yaml
@@ -1,4 +1,8 @@
 ---
+
+classes:
+    - metacpan::role::production
+
 elasticsearch::pkg_version: 0.20.2
 
 # Let's have rrr on all BM machines for now

--- a/hieradata/env/dev.yaml
+++ b/hieradata/env/dev.yaml
@@ -1,2 +1,6 @@
 ---
+
+classes:
+    - metacpan::role::developer
+
 metacpan::tmp_dir: '/tmp/metacpan'

--- a/manifests/nodes/6dg.pp
+++ b/manifests/nodes/6dg.pp
@@ -1,3 +1,0 @@
-node /6dg/ {
-  include metacpan::role::production
-}

--- a/manifests/nodes/bm.pp
+++ b/manifests/nodes/bm.pp
@@ -1,3 +1,0 @@
-node /bm/ {
-  include metacpan::role::production
-}

--- a/manifests/nodes/dev.pp
+++ b/manifests/nodes/dev.pp
@@ -1,3 +1,0 @@
-node metacpan-dev {
-  include metacpan::role::developer
-}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -54,7 +54,8 @@ resources { "firewall":
   }
 
 
-import 'nodes/*.pp'
+hiera_include('classes')
+
 
 # node bm-n2 {
 #


### PR DESCRIPTION
Fixes `import` warning in #42.
