### PR TITLE
update nginx to 1.6.2-5

### DIFF
--- a/modules/nginx/manifests/init.pp
+++ b/modules/nginx/manifests/init.pp
@@ -1,6 +1,6 @@
 class nginx {
 
-        $backport_nginx = '1.6.2-2~bpo70+1'
+        $backport_nginx = '1.6.2-5~bpo70+1'
 
         # Hard code versions
         package { "nginx-common":


### PR DESCRIPTION
provisioning was not working with 1.6.2-2, this is the latest version in backports.
