### PR TITLE
run rsync throughout the day as a stopgap

### DIFF
--- a/modules/rrrclient/manifests/cron.pp
+++ b/modules/rrrclient/manifests/cron.pp
@@ -29,9 +29,8 @@ define rrrclient::cron(
       'metacpan_daily_rsync':
           user        => $user,
           # NOTE: No "--delete" arg since we're also a backpan.
-          command     => "/usr/bin/rsync -a 23.29.118.28::PAUSE ${cpan_mirror}",
-          hour        => '23',
-          minute      => '13',
+          command     => "/usr/bin/rsync -a 23.29.118.28::PAUSE/authors/ ${cpan_mirror}/authors/ && /usr/bin/rsync -a 23.29.118.28::PAUSE/modules/ ${cpan_mirror}/modules/",
+          minute      => '*/15',
           ensure      => $ensure;
     }
 }


### PR DESCRIPTION
We cannot run rrr-client on the top level pop-up-pause-rsync because it
contains some fails which may or may not still be in CPAN. Instead we
need to mirror ./modules and ./authors. It would complicate the init
script for the rrr-client to do it there, so let's just run rsync every
15 minutes or so to start with and see if that works.
